### PR TITLE
Test with new gf-complete

### DIFF
--- a/v0.80.5-231-g9f7aa29/non-regression.sh
+++ b/v0.80.5-231-g9f7aa29/non-regression.sh
@@ -17,7 +17,6 @@
 : ${ACTION:=--check}
 : ${STRIPE_WIDTHS:=4096 4651 8192 10000 65000 65536}
 : ${VERBOSE:=} # VERBOSE=--debug-osd=20
-: ${JERASURE_VARIANTS:=generic sse3 sse4}
 : ${MYDIR:=--base $(dirname $0)}
 
 while read k m ; do

--- a/v0.86-310/non-regression.sh
+++ b/v0.86-310/non-regression.sh
@@ -17,7 +17,6 @@
 : ${ACTION:=--check}
 : ${STRIPE_WIDTHS:=4096 4651 8192 10000 65000 65536}
 : ${VERBOSE:=} # VERBOSE=--debug-osd=20
-: ${JERASURE_VARIANTS:=generic sse3 sse4}
 : ${MYDIR:=--base $(dirname $0)}
 
 while read k m l ; do


### PR DESCRIPTION
With the new support for SIMD runtime detection in gf-complete,
the non-regression tests have been modified to test with some of
the SIMD detection disabled.

All shec and jerasure tests now run with different SIMD support
turned on and off. This will ensure the decoding the corpus
with code paths that are mathematically equivalent but optimized
for different processors.
