### PR TITLE
v0.92-988/non-regression.sh: s/uname -p/arch/

### DIFF
--- a/v0.92-988/non-regression.sh
+++ b/v0.92-988/non-regression.sh
@@ -132,7 +132,7 @@ EOF
 #
 function simd_variation_action() {
 
-    arch=$(uname -p)
+    arch=$(arch)
 
     # WARNING: If you modify this function please manually test that gf-complete is
     # running the appropriate SIMD paths. One way to do that is to enable


### PR DESCRIPTION
`uname -p` returns `unknown` with a recent coreutils.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>